### PR TITLE
fix html title

### DIFF
--- a/2012/index.html
+++ b/2012/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: Call for sponsors (札幌Ruby会議2012スポンサーシップお申し込み)
 ---
 
   <header>


### PR DESCRIPTION
The html title at [index page](http://sapporo.rubykaigi.org/2012)
should not be contained info about CFS.
I removed specified title of index page.

html のタイトルが間違っていたので修正しました。
