### PR TITLE
Add '/' to the end of og:url

### DIFF
--- a/_layouts/2012default.html
+++ b/_layouts/2012default.html
@@ -12,7 +12,7 @@
 <meta content='no-cache' http-equiv='cache-control'>
 <meta property='og:title' content='Sapporo RubyKaigi 2012 (札幌Ruby会議2012)'>
 <meta property='og:site_name' content='Sapporo RubyKaigi 2012 (札幌Ruby会議2012)'>
-<meta property='og:url' content='http://sapporo.rubykaigi.org/2012/{{ page.locale }}'>
+<meta property='og:url' content='http://sapporo.rubykaigi.org/2012/{{ page.locale }}/'>
 <meta property='og:type' content='activity'>
 <meta property='og:image' content='http://sapporo.rubykaigi.org/2012/images/ogImage.png'>
 <meta property='og:description' content='Sapporo RubyKaigi 2012 (September 14th-16th, 2012)'>


### PR DESCRIPTION
The url 'http://sapporo.rubykaigi.org/2012/ja' redirects to
'http://sapporo.rubykaigi.org/2012/ja/' (end with '/').
The `og:url` should not be a redirect url.

I fixed the error of `og:url`.
ref: https://developers.facebook.com/tools/debug/og/object?q=sapporo.rubykaigi.org%2F2012%2Fja%2F
