### PR TITLE
Anglicize sample subject for ML

### DIFF
--- a/2012/ja/for_attendees.html
+++ b/2012/ja/for_attendees.html
@@ -39,7 +39,7 @@ locale: ja
     <p>To: sprk2012-list _at_ qwik.jp</p>
     <p>Cc: mayuco _at_ ruby-sapporo.org</p>
     <p>From: MLに登録したい自分のアドレス</p>
-    <p>Subject: sprk2012-listへ参加</p>
+    <p>Subject: Add me to sprk2012-list</p>
     <p>Body: 簡単なごあいさつ(本文に何か書かないと登録されません)</p>
   </div>
   <h4>英語版</h4>
@@ -47,7 +47,7 @@ locale: ja
     <p>To: sprk2012-talk _at_ qwik.jp</p>
     <p>Cc: mayuco _at_ ruby-sapporo.org</p>
     <p>From: MLに登録したい自分のアドレス</p>
-    <p>Subject: sprk2012-talkへ参加</p>
+    <p>Subject: Add me to sprk2012-talk</p>
     <p>Body: 簡単なごあいさつ(本文に何か書かないと登録されません)</p>
   </div>
   <p class="backToTop"><a href="#">Back to Top</a></p>

--- a/2012/ja/for_attendees.html
+++ b/2012/ja/for_attendees.html
@@ -46,7 +46,7 @@ locale: ja
   <div class="mlDescription">
     <p>To: sprk2012-talk _at_ qwik.jp</p>
     <p>Cc: mayuco _at_ ruby-sapporo.org</p>
-    <p>From: MLに登録したい自分のアドレス</p>
+    <p>From: The address you'd like to register with</p>
     <p>Subject: Add me to sprk2012-talk</p>
     <p>Body: A brief introduction (if you don't write something in the body, you won't be registered)</p>
   </div>

--- a/2012/ja/for_attendees.html
+++ b/2012/ja/for_attendees.html
@@ -48,7 +48,7 @@ locale: ja
     <p>Cc: mayuco _at_ ruby-sapporo.org</p>
     <p>From: MLに登録したい自分のアドレス</p>
     <p>Subject: Add me to sprk2012-talk</p>
-    <p>Body: 簡単なごあいさつ(本文に何か書かないと登録されません)</p>
+    <p>Body: A brief introduction (if you don't write something in the body, you won't be registered)</p>
   </div>
   <p class="backToTop"><a href="#">Back to Top</a></p>
 </article>


### PR DESCRIPTION
サンプルとして書いてある ML の Subject を英語表記にしました。

今までのサンプルのままで ML に参加表明すると、英語用の ML に日本語のタイトルで投稿されます。
英語用の ML に送信するタイトルは英語である方が親切だと思い修正しました。

さらに、talk も list も英語表記に統一してもよいかと思ったので、 list もあわせて修正しました。
