### PR TITLE
Fix link to floor guide

### DIFF
--- a/2012/en/for_attendees.html
+++ b/2012/en/for_attendees.html
@@ -17,11 +17,11 @@ locale: en
 <article id="floorguide">
   <h2>Floor Guide</h2>
   <h3>14th</h3>
-  <p><a href="/2012/documents/floorguide14th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
-  <p><a href="/2012/documents/floorguide14th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide14th.png"></a></p>
+  <p><a href="/2012/documents/floorGuide14th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
+  <p><a href="/2012/documents/floorGuide14th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide14th.png"></a></p>
   <h3>15-16th</h3>
-  <p><a href="/2012/documents/floorguide15-16th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
-  <p><a href="/2012/documents/floorguide15-16th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide15-16th.png"></a></p>
+  <p><a href="/2012/documents/floorGuide15-16th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
+  <p><a href="/2012/documents/floorGuide15-16th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide15-16th.png"></a></p>
   <p class="backToTop"><a href="#">Back to Top</a></p>
 </article>
 <article id="hotels">

--- a/2012/ja/for_attendees.html
+++ b/2012/ja/for_attendees.html
@@ -17,11 +17,11 @@ locale: ja
 <article id="floorguide">
   <h2>フロアガイド</h2>
   <h3>14日</h3>
-  <p><a href="/2012/documents/floorguide14th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
-  <p><a href="/2012/documents/floorguide14th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide14th.png"></a></p>
+  <p><a href="/2012/documents/floorGuide14th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
+  <p><a href="/2012/documents/floorGuide14th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide14th.png"></a></p>
   <h3>15-16日</h3>
-  <p><a href="/2012/documents/floorguide15-16th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
-  <p><a href="/2012/documents/floorguide15-16th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide15-16th.png"></a></p>
+  <p><a href="/2012/documents/floorGuide15-16th.pdf" target="_blank" class="linkMark">DOWNLOAD (PDF)</a></p>
+  <p><a href="/2012/documents/floorGuide15-16th.pdf" target="_blank"><img src="/2012/images/forAttendeesFloorGuide15-16th.png"></a></p>
   <p class="backToTop"><a href="#">Back to Top</a></p>
 </article>
 <article id="lunchmap">


### PR DESCRIPTION
Download floor guide link at [for attendees](http://sapporo.rubykaigi.org/2012/en/for_attendees.html#floorguide) returns `404`.
- http://sapporo.rubykaigi.org/2012/documents/floorguide14th.pdf
- http://sapporo.rubykaigi.org/2012/documents/floorguide15-16th.pdf

I fixed `href` to PDF file.
- floorguide -> floorGuide
