### PR TITLE
Add 'toRuby' as a sub event

### DIFF
--- a/2012/_schedule/lib/templates/grid.erb
+++ b/2012/_schedule/lib/templates/grid.erb
@@ -235,6 +235,15 @@ localmenu: <%=
 <article id="subEvent">
       <%- if I18n.locale == :ja -%>
         <h2>サブイベント</h2>
+        <h3 id="subEvent2">またやる出張版toRuby（併設The dRuby Bookサイン会）</h3>
+        <p>RubyKaigi2011でこっそり開催した、ゆRubyのtoRubyパートをまたやります。ゆるくぬるい勉強会です。島根大の講義のテキストを使った「dRuby体験」です。一台のマシンで複数のプログラムが協調しあう様子を体験します。PC必要。ない人はとなりの席の人とペアプロしよう！</p>
+        <ul class="listMarkRed">
+          <li>9月15日（土）12:30 - 13:20 (12:00-12:30は会場でランチ)</li>
+          <li><a href="http://atnd.org/events/31976">http://atnd.org/events/31976</a> にてご登録ください。</li>
+          <li><a href="http://d.hatena.ne.jp/m_seki/20110712#1310418121">http://d.hatena.ne.jp/m_seki/20110712#1310418121</a></li>
+          <li>関将俊(@m_seki) - toRuby70回くらい皆勤賞の咳です。</li>
+          <li>米澤慎(@vestige_) - toRubyで安定の司会業の米澤です。</li>
+        </ul>
         <h3 id="subEvent1">try(:english)</h3>
         <p>All English!! 英語のネイティブスピーカーと英語で話しをしてみよう！お昼時にピザ付きのミートアップです。英語２、日本語２程度の小さなグループで、ガイジンRubyistsと直に話しをしてみよう。俄然、英語がんばるぞ、という気持ちになります。ぜひ、ご参加ください。</p>
         <ul class="listMarkRed">

--- a/2012/ja/schedule.html
+++ b/2012/ja/schedule.html
@@ -387,6 +387,15 @@ localmenu: <li><a href="#schedule14">9月14日(金)</a></li><li><a href="#schedu
 </article>
 <article id="subEvent">
         <h2>サブイベント</h2>
+        <h3 id="subEvent2">またやる出張版toRuby（併設The dRuby Bookサイン会）</h3>
+        <p>RubyKaigi2011でこっそり開催した、ゆRubyのtoRubyパートをまたやります。ゆるくぬるい勉強会です。島根大の講義のテキストを使った「dRuby体験」です。一台のマシンで複数のプログラムが協調しあう様子を体験します。PC必要。ない人はとなりの席の人とペアプロしよう！</p>
+        <ul class="listMarkRed">
+          <li>9月15日（土）12:30 - 13:20 (12:00-12:30は会場でランチ)</li>
+          <li><a href="http://atnd.org/events/31976">http://atnd.org/events/31976</a> にてご登録ください。</li>
+          <li><a href="http://d.hatena.ne.jp/m_seki/20110712#1310418121">http://d.hatena.ne.jp/m_seki/20110712#1310418121</a></li>
+          <li>関将俊(@m_seki) - toRuby70回くらい皆勤賞の咳です。</li>
+          <li>米澤慎(@vestige_) - toRubyで安定の司会業の米澤です。</li>
+        </ul>
         <h3 id="subEvent1">try(:english)</h3>
         <p>All English!! 英語のネイティブスピーカーと英語で話しをしてみよう！お昼時にピザ付きのミートアップです。英語２、日本語２程度の小さなグループで、ガイジンRubyistsと直に話しをしてみよう。俄然、英語がんばるぞ、という気持ちになります。ぜひ、ご参加ください。</p>
         <ul class="listMarkRed">


### PR DESCRIPTION
サブイベントに「またやる出張版toRuby（併設The dRuby Bookサイン会）」を追加しました。
日本語版のみです。
