### PR TITLE
Gravatar icon

### DIFF
--- a/2012/_schedule/lib/sprk2012_schedule.rb
+++ b/2012/_schedule/lib/sprk2012_schedule.rb
@@ -252,6 +252,10 @@ module SPRK2012
     def github
       data['github']
     end
+
+    def gravatar
+      data['gravatar']
+    end
   end
 
   # サブイベント

--- a/2012/_schedule/lib/templates/detail.erb
+++ b/2012/_schedule/lib/templates/detail.erb
@@ -26,10 +26,10 @@ title_long: |-
   <%= md(presenter.bio) %>
   <h3>GitHub</h3>
     <% if presenter.github -%>
-      <%- [*presenter.github].each do |github| -%>
+      <%- [[*presenter.github].zip([*presenter.gravatar])].each do |(github, gravatar), | -%>
     <p>
       <a href="https://github.com/<%= github %>"><%= github %></a><br>
-      <img src="http://usericons.relucks.org/github/<%= github %>" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/<%= gravatar %>?s=140" width="120" height="120">
     </p>
       <%- end -%>
     <%- else -%>

--- a/2012/_schedule/presentations/11.yml
+++ b/2012/_schedule/presentations/11.yml
@@ -12,6 +12,7 @@ presenters:
         Kazuki Tsujimoto is an infrastructure engineer at Nomura Research Institute, Ltd.
         He is also a CRuby committer.
     github: k-tsj
+    gravatar: 303dd57f37d64288bb4f0336332a8882
 title:
   ja:
   en: Pattern Matching in Ruby

--- a/2012/_schedule/presentations/13.yml
+++ b/2012/_schedule/presentations/13.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 柴田博志
       en: SHIBATA Hiroshi
     github: hsbt
+    gravatar: eabad423977cfc6873b8f5df62b848a6
     affiliation:
       ja: 株式会社paperboy&co., asakusa.rb
       en: paperboy&co., Inc., asakusa.rb

--- a/2012/_schedule/presentations/14.yml
+++ b/2012/_schedule/presentations/14.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 設樂 洋爾
       en: Yoji Shidara
     github: darashi
+    gravatar: 817b7699ccbd3a6664de66eee8c2cbd2
     affiliation:
       ja: Team OyasumiSupport#end_of_day, 株式会社えにしテック
       en: Team OyasumiSupport#end_of_day, Enishi Tech Inc.

--- a/2012/_schedule/presentations/17.yml
+++ b/2012/_schedule/presentations/17.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 諸橋恭介
       en: Kyosuke MOROHASHI.
     github: moro
+    gravatar: 70e13d9877054026fda46d5a5b53a236
     affiliation:
       ja: (株)永和システムマネジメント (http://www.esm.co.jp)
       en: Eiwa System Management, Inc. (http://www.esm.co.jp)

--- a/2012/_schedule/presentations/18.yml
+++ b/2012/_schedule/presentations/18.yml
@@ -10,6 +10,7 @@ presenters:
       ja: Rubyプログラマ。
       en: A Ruby programmer.
     github: shugo
+    gravatar: 18a797893e6768e048c1d15429f96bb4
 title:
   ja:
   en: Purely functional programming in Ruby

--- a/2012/_schedule/presentations/20.yml
+++ b/2012/_schedule/presentations/20.yml
@@ -11,6 +11,7 @@ presenters:
       en: |-
         I realized I wanted to learn practical programming skills so once I found out about Ruby in college I immediately installed Locomotive on my Mac. Was extremely excited to find out I already had Ruby 1.8.6 preinstalled on my iBook G4 and started hacking on my first Rails project. I find teaching to be enjoyable and have been participating in the SF RailsBridge every so often. I'm still a level 1 whiskey/whisky drinker, but I'm working on that. Currently I am working at GitHub doing cool stuff.
     github: danishkhan
+    gravatar: 7f81fd5c7792dabca22c433abbfbf0cb
 title:
   ja: Γυβψ のコミュニティ
   en: Γυβψ Community

--- a/2012/_schedule/presentations/22.yml
+++ b/2012/_schedule/presentations/22.yml
@@ -4,6 +4,7 @@ presenters:
       ja: アンドリュー グリム
       en: Andrew Grimm
     github: agrimm
+    gravatar: 01bbb59a1c3ef9960f25a97afe7e920f
     affiliation:
       ja: ニューサウスウェールズ大学 (UNSW)
       en: University of New South Wales.

--- a/2012/_schedule/presentations/25.yml
+++ b/2012/_schedule/presentations/25.yml
@@ -13,6 +13,7 @@ presenters:
         awesome. When he's not coding you can probably find him improving his circus
         skills around the beautiful San Francisco.
     github: calavera
+    gravatar: 0c39b828636367fc6e22b7be8c803c74
 title:
   ja:
   en: Scaling in the unknown, how GitHub develops, ships and supports GitHub Enterprise.

--- a/2012/_schedule/presentations/27.yml
+++ b/2012/_schedule/presentations/27.yml
@@ -10,6 +10,7 @@ presenters:
       ja: 中卒フリーター兼 Ruby コミッター ("偽りの厨二")。そらはーと呼ばれています。クックパッド株式会社でアルバイトしてます。 http://sorah.jp/
       en: A Ruby committer. Coding part-time at COOKPAD Inc. (of course I code socially) http://sorah.jp/
     github: sorah
+    gravatar: 626ca235e8dab778c5bad6fc10e94ad8
 title:
   ja: Social Coding をはじめよう
   en: Guide to Social Coding

--- a/2012/_schedule/presentations/28.yml
+++ b/2012/_schedule/presentations/28.yml
@@ -13,6 +13,7 @@ presenters:
         he's building gems you've never heard of or contributing to projects you
         have such as Rubinius, Radiant CMS or the Heroku Gem.
     github: daneharrigan
+    gravatar: e8c88afd8e2c1b5efa3b18e7a6ed6722
 title:
   ja:
   en: Finding True Love in Legacy Software

--- a/2012/_schedule/presentations/29.yml
+++ b/2012/_schedule/presentations/29.yml
@@ -10,6 +10,7 @@ presenters:
       ja: GC好き。
       en: a GC lover.
     github: authorNari
+    gravatar: 9f859654c118bcd2f67cc763baf0de7a
 title:
   ja: Rubyによる本気のGC
   en: Serious GC with Ruby

--- a/2012/_schedule/presentations/3.yml
+++ b/2012/_schedule/presentations/3.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 村田賢太
       en: Kenta Murata
     github: mrkn
+    gravatar: f92d08fba5207992c4e6b85ab9515a2f
     affiliation:
       ja: クックパッド株式会社 && Asakusa.rb && Ruby 札幌
       en: COOKPAD Inc. && Asakusa.rb && Ruby Sapporo

--- a/2012/_schedule/presentations/37.yml
+++ b/2012/_schedule/presentations/37.yml
@@ -11,6 +11,7 @@ presenters:
       en: |-
         Josh Lane is an engineer at Engine Yard and lives in Oakland. He hails from Boston where he worked for HubSpot, Brontes Technologies and EMC.
     github: lanej
+    gravatar: ba7a9f06b6e43aff99e437309f33c73e
 title:
   ja:
   en: |-

--- a/2012/_schedule/presentations/40.yml
+++ b/2012/_schedule/presentations/40.yml
@@ -11,6 +11,7 @@ presenters:
       en: |-
         Tatsuhiko Miyagawa is a software engineer at COOKPAD. He grew up in Tokyo and Yokohama, and has been living in San Francisco since 2006. He is an author of hundreds of open source software published on GitHub, CPAN and RubyGems, and also known as a founder of Shibuya.pm and the world popular grass-roots Perl conference YAPC::Asia.
     github: miyagawa
+    gravatar: 49e1240c84b221f3dcca57d005a2f569
 title:
   ja:
   en: Ruby; Exported

--- a/2012/_schedule/presentations/45.yml
+++ b/2012/_schedule/presentations/45.yml
@@ -4,6 +4,7 @@ presenters:
       ja:
       en: Kenji Okimoto (a.k.a okkez)
     github: okkez
+    gravatar: 9673ac7770ee09f76ff5d839820db157
     affiliation:
       ja: 株式会社クリアコード
       en: ClearCode Inc.

--- a/2012/_schedule/presentations/46.yml
+++ b/2012/_schedule/presentations/46.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 長永 健介
       en: Kensuke Nagae
     github: kyanny
+    gravatar: fffd8bf62b842a46803fb07792029fa4
     affiliation:
       ja: 株式会社paperboy&co.
       en: paperboy&co., Inc.

--- a/2012/_schedule/presentations/47.yml
+++ b/2012/_schedule/presentations/47.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 白土 慧
       en: Kei Shiratsuchi
     github: kei-s
+    gravatar: bf7ce9b68bbb0058721906b4db15b9b5
     affiliation:
       ja: Ruby札幌
       en: Ruby Sapporo

--- a/2012/_schedule/presentations/48.yml
+++ b/2012/_schedule/presentations/48.yml
@@ -12,6 +12,7 @@ presenters:
       en: |-
         Techinical Manager of [paperboy&co., Inc](http://paperboy.co.jp).
     github: mizzy
+    gravatar: 0d5d8fb9cc4c06f581825f5a61d3f5f1
 title:
   ja: Sqale の裏側
   en: Inside Sqale's Backend

--- a/2012/_schedule/presentations/52.yml
+++ b/2012/_schedule/presentations/52.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 原田　洋子
       en: Yoko Harada
     github: yokolet
+    gravatar: e184bc2347f90dd61b509de6eb43a8b6
     affiliation:
       ja: JRuby/Nokogiriプロジェクト
       en: JRuby/Nokogiri Project

--- a/2012/_schedule/presentations/53.yml
+++ b/2012/_schedule/presentations/53.yml
@@ -18,6 +18,7 @@ presenters:
         Mail clerk and Door man at asakusa.rb
         I have held Rails Study @ Tokyo.
     github: takkanm
+    gravatar: 8f39a252784d5a99589be6e20c4553fb
 title:
   ja: ソーシャルコーディング時代のふつうのプログラマサバイバルガイド
   en: |-

--- a/2012/_schedule/presentations/54.yml
+++ b/2012/_schedule/presentations/54.yml
@@ -12,6 +12,7 @@ presenters:
       ja: Rubyist, 株式会社万葉のエンジニア
       en: Rubyist, The engineer of everyleaf.com
     github: tatsuo
+    gravatar: 092404bdf9897eba9ab16e61f56592db
 title:
   ja: たのしい開発へ至る道
   en: The Way of Fun Development

--- a/2012/_schedule/presentations/56.yml
+++ b/2012/_schedule/presentations/56.yml
@@ -10,6 +10,7 @@ presenters:
       ja:
       en: A Ruby (MRI) developer (Virtual machine), Heroku, Inc.
     github: ko1
+    gravatar: 308cbef6e86dfc49cce3b2d4cf42aedc
 title:
   ja:
   en: |-

--- a/2012/_schedule/presentations/58.yml
+++ b/2012/_schedule/presentations/58.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 向井ジョニー
       en: Jonathan Mukai-Heidt
     github: johnnymugs
+    gravatar: 642a8d148b8a6969e8e4db525a401636
     affiliation:
       ja: Pivotal Labs (NYC)
       en: Pivotal Labs (NYC)

--- a/2012/_schedule/presentations/59.yml
+++ b/2012/_schedule/presentations/59.yml
@@ -10,6 +10,7 @@ presenters:
       ja: クックパッド技術部長。Web テクノロジー全般が好き。
       en: Software Enginner at Cookpad
     github: hotchpotch
+    gravatar: 2997ec7879942bd0415690c85731e328
 title:
   ja: 料理を支える技術 2012
   en: Technology that drives fun cooking 2012

--- a/2012/_schedule/presentations/64.yml
+++ b/2012/_schedule/presentations/64.yml
@@ -10,6 +10,7 @@ presenters:
       ja: (株)永和システムマネジメント所属のチーフプログラマ兼主任整備士。RubyとGentooとKinesisが好き。
       en: Chief programmer and chief mechanic at Eiwa System Management, Inc. I love Ruby, Gentoo Linux, and Kinesis Contoured Keyboard.
     github: ursm
+    gravatar: f966e93db0fbaf3aa07f7df5fa136933
 title:
   ja:
   en: |-

--- a/2012/_schedule/presentations/7.yml
+++ b/2012/_schedule/presentations/7.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 須藤功平
       en: Kouhei Sutou
     github: kou
+    gravatar: ee6ffca720cc428d70247dcd7377dd48
     affiliation:
       ja: 株式会社クリアコード
       en: ClearCode Inc.

--- a/2012/_schedule/presentations/70.yml
+++ b/2012/_schedule/presentations/70.yml
@@ -4,6 +4,7 @@ presenters:
       ja: タシツキ ミハウ
       en: Taszycki Michal
     github: mehowte
+    gravatar: 85977ebfe59c2ee669f2196930f1a701
     affiliation:
       ja: アップリケーキ
       en: Applicake

--- a/2012/_schedule/presentations/72.yml
+++ b/2012/_schedule/presentations/72.yml
@@ -4,6 +4,7 @@ presenters:
       ja:
       en: Linda Liukas
     github: lindaliukas
+    gravatar: 51eb230f66c064daafb36264398c0252
     affiliation:
       ja:
       en: Community Manager at Codecademy, co-founder of Rails Girls

--- a/2012/_schedule/presentations/74.yml
+++ b/2012/_schedule/presentations/74.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 原 悠
       en: Yutaka HARA
     github: yhara
+    gravatar: 22270b6a4e909f6b926fa272596d41b9
     affiliation:
       ja: (株)ネットワーク応用通信研究所
       en: Network Applied Communication Laboratory Ltd.

--- a/2012/_schedule/presentations/75.yml
+++ b/2012/_schedule/presentations/75.yml
@@ -10,6 +10,7 @@ presenters:
       ja: ソフトウェア開発者
       en: A software developer.
     github: tricknotes
+    gravatar: dc03a27ae31ba428c560c00c9128cd75
 title:
   ja: コミュニティのある風景。
   en: The development with community.

--- a/2012/_schedule/presentations/78.yml
+++ b/2012/_schedule/presentations/78.yml
@@ -15,6 +15,7 @@ presenters:
         The author of gem libraries e.g. [kaminari](https://github.com/amatsuda/kaminari), [erd](https://github.com/amatsuda/erd)
         A Rails maniac.
     github: amatsuda
+    gravatar: 76a777ff80f30bd3b390e275cce625bc
 title:
   ja: Rails3レシピブック外伝
   en: Rails3 Recipe Book Gaiden

--- a/2012/_schedule/presentations/79.yml
+++ b/2012/_schedule/presentations/79.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 角谷 信太郎
       en: Kakutani Shintaro
     github: kakutani
+    gravatar: 63a6bff89d692e21de20868202bc8dde
     affiliation:
       ja: 一般社団法人日本Rubyの会 || (株)永和システムマネジメント
       en: Ruby no Kai (Japan Ruby Group) || Eiwa System Management, Inc.

--- a/2012/_schedule/presentations/8.yml
+++ b/2012/_schedule/presentations/8.yml
@@ -12,6 +12,7 @@ presenters:
         Saurabh Bhatia is one of the early adopters of Rails and has been working since 2006 on it. Before this he was a java developer
         and active participant in Indian Open Source scene. He has written at in various magazines (rails magazine, linux user and developer, UK, linux for you, India ) and actively mentored at RailsBridge. He spoke at RubyConf Brasil 2011 on HTML5 wesockets and Rails. He is also an active participant in Openstack communities.
     github: saurabhbhatia
+    gravatar: e0fe062ff7f5d75b8e13773340370db5
 title:
   ja:
   en: Ruboto - Ruby on Android

--- a/2012/_schedule/presentations/81.yml
+++ b/2012/_schedule/presentations/81.yml
@@ -12,6 +12,7 @@ presenters:
         Yuichiro is Open source developer who's known as Furo-grammer. I'm writing this proposal in the hot-tub.
         I have been developping PukiWiki what's most popular WikiEngine.
     github: masuidrive
+    gravatar: 0ec58a040e1e4e959c8566484b4bba19
 title:
   ja:
   en: Ruby + iOS = Super awesome!

--- a/2012/_schedule/presentations/82.yml
+++ b/2012/_schedule/presentations/82.yml
@@ -4,6 +4,7 @@ presenters:
       ja:
       en: Nick Sutterer
     github: apotonick
+    gravatar: 0fe13386ba69a128e9fadc19ae9d96be
     affiliation:
       ja:
       en: Software Architect

--- a/2012/_schedule/presentations/84.yml
+++ b/2012/_schedule/presentations/84.yml
@@ -4,6 +4,7 @@ presenters:
       ja: 江渡 浩一郎
       en: Koichiro Eto
     github: eto
+    gravatar: ee67564a1a0e290cccf3c4a415e51c48
     affiliation:
       ja: 独立行政法人 産業技術総合研究所
       en: National Institute of Advanced Industrial Science and Technology (AIST)

--- a/2012/_schedule/presentations/K02.yml
+++ b/2012/_schedule/presentations/K02.yml
@@ -10,6 +10,7 @@ presenters:
       ja: 張本人。ええ、みんな私のせいです
       en: The one who started everything.
     github: matz
+    gravatar: 0ec4920185b657a03edf01fff96b4e9b
 title:
   ja: One size does not fit all
   en: One size does not fit all

--- a/2012/_schedule/presentations/K03.yml
+++ b/2012/_schedule/presentations/K03.yml
@@ -14,6 +14,7 @@ presenters:
         Eric lives in Seattle and is a member of Seattle.rb.  In his spare
         time he practices astronomy and plays video games.
     github: drbrain
+    gravatar: 58479f76374a3ba3c69b9804163f39f4
 title:
   ja:
   en: Writing Ruby for Fun

--- a/2012/_schedule/presentations/LT01.yml
+++ b/2012/_schedule/presentations/LT01.yml
@@ -4,6 +4,7 @@ presenters:
       en: Kentaro Kuribayashi
       ja: 栗林 健太郎
     github: kentaro
+    gravatar: 23f4d5d797a91b6d17d627b90b5a42d9
     affiliation:
       en: paperboy&co., Inc
       ja: paperboy&co., Inc

--- a/2012/_schedule/presentations/LT02.yml
+++ b/2012/_schedule/presentations/LT02.yml
@@ -4,6 +4,7 @@ presenters:
       en: Randy Morgan # required
       ja: モーガン・ランディ
     github: randym # required
+    gravatar: 855975ff404621dc525c72b618d95dcc # required
     affiliation:
       en: reallyenglish # required
       ja: リアル・イングリッシュ・ブロードバンド株式会社

--- a/2012/_schedule/presentations/LT03.yml
+++ b/2012/_schedule/presentations/LT03.yml
@@ -3,6 +3,7 @@ presenters:
   - name:
       en: Naoto Takai
     github: takai
+    gravatar: cf7b553387b247d737c60cfceabb2cea
     affiliation:
       en: COOKPAD Inc.
     bio:

--- a/2012/_schedule/presentations/LT05.yml
+++ b/2012/_schedule/presentations/LT05.yml
@@ -3,6 +3,7 @@ presenters:
   - name:
       en: Hibariya # required
     github: hibariya # required
+    gravatar: de0df5acda15a9c7eeb6c28a5e5d4e8e # required
     affiliation:
       en: Eiwa System Management, Inc. # required
     bio:

--- a/2012/_schedule/presentations/LT06.yml
+++ b/2012/_schedule/presentations/LT06.yml
@@ -4,6 +4,7 @@ presenters:
       en: Kazuya NUMATA
       ja: 沼田 一哉
     github: kaznum
+    gravatar: fbcf9ed09205a5093069f0a2ccccfdf8
     affiliation:
       en: ESTCOSMO Co., Ltd., LOCAL, Ruby Sapporo
       ja: 株式会社エストコスモ, 一般社団法人LOCAL, Ruby札幌

--- a/2012/_schedule/presentations/LT09.yml
+++ b/2012/_schedule/presentations/LT09.yml
@@ -4,6 +4,7 @@ presenters:
       en: Yohei YASUKAWA # required
       ja: 安川　要平 # optional
     github: yasulab # required
+    gravatar: f9e2dfe1e5e7b40cfe5bafa0c730293d # required
     affiliation:
       en: Freelance Developer # required
       ja: フリーランス # optional

--- a/2012/_schedule/presentations/LT10.yml
+++ b/2012/_schedule/presentations/LT10.yml
@@ -4,6 +4,7 @@ presenters:
       en: Masayoshi Takahashi and Yurie Yamane
       ja: 高橋征義・やまねゆりえ
     github: [takahashim, yurie]
+    gravatar: [21a4b941766d805333e11c5766be43b4, 0607f2778a478327d55f9b4fb7954a60]
     affiliation:
       en: Tatsu-zine Publishing Inc.
       ja: 株式会社達人出版会

--- a/2012/_schedule/presentations/LT12.yml
+++ b/2012/_schedule/presentations/LT12.yml
@@ -3,6 +3,7 @@ presenters:
   - name:
       en: Masatoshi SEKI # required
     github: seki # required
+    gravatar: bdcb9af0b168cf425bac2d3772164bee # required
     affiliation:
       en: toRuby # required
     bio:

--- a/2012/_schedule/presentations/LT14.yml
+++ b/2012/_schedule/presentations/LT14.yml
@@ -4,6 +4,7 @@ presenters:
       en: Toshiaki Koshiba
       ja: こしば としあき
     github: bash0C7
+    gravatar: 9d2d4c8b739b1b4d7882ba49dcf1d276
     affiliation:
       en: Tokyo RubyKaigi 10 Executive Committee,  DevLOVE Pub
       ja: 東京Ruby会議10実行委員会, DevLOVE Pub

--- a/2012/_schedule/presentations/LT15.yml
+++ b/2012/_schedule/presentations/LT15.yml
@@ -4,6 +4,7 @@ presenters:
       en: Kazuhiro NISHIYAMA # required
       ja: 西山和広 # optional
     github: znz # required
+    gravatar: 8e497efbe99e2fa051316337d03624d9 # required
     affiliation:
       en: nadoka developers # required
       ja: # optional

--- a/2012/_schedule/presentations/LT16.yml
+++ b/2012/_schedule/presentations/LT16.yml
@@ -4,6 +4,7 @@ presenters:
       en: Takeshi SHINODA
       ja: 篠田 健
     github: takeshinoda
+    gravatar: 06febd004d7cc9c9f6a4e0272b686bc7
     affiliation:
       en: Nihon Unisys, Ltd.
       ja: 日本ユニシス株式会社

--- a/2012/_schedule/presentations/P01.yml
+++ b/2012/_schedule/presentations/P01.yml
@@ -10,6 +10,7 @@ presenters:
       ja: (株) 永和システムマネジメントで働くRubyプログラマ。RubyとGentooとタイル型Window Managerが好き。
       en: Ruby programmer at Eiwa System Management, Inc. He loves Ruby, Gentoo Linux and Tiling Window Manager.
     github: kenchan
+    gravatar: 676954675cda206b7baae939a82a8ef4
 title:
   ja: ふつうのソーシャルコーディング
   en: Social Coding, It's Not Unusual in ESM

--- a/2012/_schedule/presentations/R02.yml
+++ b/2012/_schedule/presentations/R02.yml
@@ -20,6 +20,7 @@ presenters:
         that can bring happiness to real people by capitalizing on the
         world's best technology.
     github: ihara2525
+    gravatar: b16a7b3fa409bb986aef592e21b46ecc
 title:
   ja: クックパッドのつくりかた
   en: How to create COOKPAD

--- a/2012/en/schedule/details/11.html
+++ b/2012/en/schedule/details/11.html
@@ -27,7 +27,7 @@ He is also a CRuby committer.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/k-tsj">k-tsj</a><br>
-      <img src="http://usericons.relucks.org/github/k-tsj" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/303dd57f37d64288bb4f0336332a8882?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/13.html
+++ b/2012/en/schedule/details/13.html
@@ -32,7 +32,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hsbt">hsbt</a><br>
-      <img src="http://usericons.relucks.org/github/hsbt" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/14.html
+++ b/2012/en/schedule/details/14.html
@@ -24,7 +24,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/darashi">darashi</a><br>
-      <img src="http://usericons.relucks.org/github/darashi" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Talk will be in Japanese, but slides will be provided in both English and Japanese.</p>

--- a/2012/en/schedule/details/17.html
+++ b/2012/en/schedule/details/17.html
@@ -31,7 +31,7 @@ Newbies often worry about &#39;What to test?&#39; or &#39;How many tests should 
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/moro">moro</a><br>
-      <img src="http://usericons.relucks.org/github/moro" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/18.html
+++ b/2012/en/schedule/details/18.html
@@ -29,7 +29,7 @@ evaluation</a>).</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/shugo">shugo</a><br>
-      <img src="http://usericons.relucks.org/github/shugo" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/20.html
+++ b/2012/en/schedule/details/20.html
@@ -30,7 +30,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/danishkhan">danishkhan</a><br>
-      <img src="http://usericons.relucks.org/github/danishkhan" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/7f81fd5c7792dabca22c433abbfbf0cb?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/22.html
+++ b/2012/en/schedule/details/22.html
@@ -28,7 +28,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/agrimm">agrimm</a><br>
-      <img src="http://usericons.relucks.org/github/agrimm" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English (slides will be in both English and Japanese)</p>

--- a/2012/en/schedule/details/25.html
+++ b/2012/en/schedule/details/25.html
@@ -28,7 +28,7 @@ skills around the beautiful San Francisco.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/calavera">calavera</a><br>
-      <img src="http://usericons.relucks.org/github/calavera" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0c39b828636367fc6e22b7be8c803c74?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/27.html
+++ b/2012/en/schedule/details/27.html
@@ -54,7 +54,7 @@ yet. (for Japanese developers...)</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/sorah">sorah</a><br>
-      <img src="http://usericons.relucks.org/github/sorah" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/626ca235e8dab778c5bad6fc10e94ad8?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/28.html
+++ b/2012/en/schedule/details/28.html
@@ -36,7 +36,7 @@ have such as Rubinius, Radiant CMS or the Heroku Gem.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/daneharrigan">daneharrigan</a><br>
-      <img src="http://usericons.relucks.org/github/daneharrigan" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/e8c88afd8e2c1b5efa3b18e7a6ed6722?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/29.html
+++ b/2012/en/schedule/details/29.html
@@ -24,7 +24,7 @@ write serious GC, not a toy.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/authorNari">authorNari</a><br>
-      <img src="http://usericons.relucks.org/github/authorNari" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/3.html
+++ b/2012/en/schedule/details/3.html
@@ -31,7 +31,7 @@ I will demonstrate the effectiveness of the library by showing the time saved by
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/mrkn">mrkn</a><br>
-      <img src="http://usericons.relucks.org/github/mrkn" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/f92d08fba5207992c4e6b85ab9515a2f?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/37.html
+++ b/2012/en/schedule/details/37.html
@@ -22,7 +22,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/lanej">lanej</a><br>
-      <img src="http://usericons.relucks.org/github/lanej" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/ba7a9f06b6e43aff99e437309f33c73e?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/40.html
+++ b/2012/en/schedule/details/40.html
@@ -25,7 +25,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/miyagawa">miyagawa</a><br>
-      <img src="http://usericons.relucks.org/github/miyagawa" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/49e1240c84b221f3dcca57d005a2f569?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English + Japanese</p>

--- a/2012/en/schedule/details/45.html
+++ b/2012/en/schedule/details/45.html
@@ -27,7 +27,7 @@ He is also working on Ruby reference manual renovation plan in his spare time.</
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/okkez">okkez</a><br>
-      <img src="http://usericons.relucks.org/github/okkez" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/46.html
+++ b/2012/en/schedule/details/46.html
@@ -26,7 +26,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kyanny">kyanny</a><br>
-      <img src="http://usericons.relucks.org/github/kyanny" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/47.html
+++ b/2012/en/schedule/details/47.html
@@ -30,7 +30,7 @@ He is from Sapporo, and loves JavaScript and Ruby.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kei-s">kei-s</a><br>
-      <img src="http://usericons.relucks.org/github/kei-s" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/48.html
+++ b/2012/en/schedule/details/48.html
@@ -26,7 +26,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/mizzy">mizzy</a><br>
-      <img src="http://usericons.relucks.org/github/mizzy" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0d5d8fb9cc4c06f581825f5a61d3f5f1?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese (A slide is written by English)</p>

--- a/2012/en/schedule/details/52.html
+++ b/2012/en/schedule/details/52.html
@@ -30,7 +30,7 @@ Yoko keeps contributing both JRuby and Nokogiri projects.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/yokolet">yokolet</a><br>
-      <img src="http://usericons.relucks.org/github/yokolet" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/e184bc2347f90dd61b509de6eb43a8b6?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/53.html
+++ b/2012/en/schedule/details/53.html
@@ -36,7 +36,7 @@ I have held Rails Study @ Tokyo.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takkanm">takkanm</a><br>
-      <img src="http://usericons.relucks.org/github/takkanm" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/54.html
+++ b/2012/en/schedule/details/54.html
@@ -28,7 +28,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/tatsuo">tatsuo</a><br>
-      <img src="http://usericons.relucks.org/github/tatsuo" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/56.html
+++ b/2012/en/schedule/details/56.html
@@ -30,7 +30,7 @@ the release of Ruby 2.0.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/ko1">ko1</a><br>
-      <img src="http://usericons.relucks.org/github/ko1" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/308cbef6e86dfc49cce3b2d4cf42aedc?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/58.html
+++ b/2012/en/schedule/details/58.html
@@ -22,7 +22,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/johnnymugs">johnnymugs</a><br>
-      <img src="http://usericons.relucks.org/github/johnnymugs" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/642a8d148b8a6969e8e4db525a401636?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/59.html
+++ b/2012/en/schedule/details/59.html
@@ -27,7 +27,7 @@ Example upgrade Rails 2.3 to 3, maintenance code.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hotchpotch">hotchpotch</a><br>
-      <img src="http://usericons.relucks.org/github/hotchpotch" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/64.html
+++ b/2012/en/schedule/details/64.html
@@ -24,7 +24,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/ursm">ursm</a><br>
-      <img src="http://usericons.relucks.org/github/ursm" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/f966e93db0fbaf3aa07f7df5fa136933?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/7.html
+++ b/2012/en/schedule/details/7.html
@@ -31,7 +31,7 @@ programmers about how he codes clear code.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kou">kou</a><br>
-      <img src="http://usericons.relucks.org/github/kou" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/ee6ffca720cc428d70247dcd7377dd48?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/70.html
+++ b/2012/en/schedule/details/70.html
@@ -87,7 +87,7 @@ Michał enjoys pushing people out of their comfort zones and into new rewarding 
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/mehowte">mehowte</a><br>
-      <img src="http://usericons.relucks.org/github/mehowte" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/85977ebfe59c2ee669f2196930f1a701?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English | Japanese</p>

--- a/2012/en/schedule/details/72.html
+++ b/2012/en/schedule/details/72.html
@@ -34,7 +34,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/lindaliukas">lindaliukas</a><br>
-      <img src="http://usericons.relucks.org/github/lindaliukas" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/51eb230f66c064daafb36264398c0252?s=140" width="120" height="120">
     </p>
   <h2>Speaker</h2>
   <p>Terence Lee</p>
@@ -47,7 +47,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hone">hone</a><br>
-      <img src="http://usericons.relucks.org/github/hone" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/74.html
+++ b/2012/en/schedule/details/74.html
@@ -33,7 +33,7 @@ This will be my 4th visit to Sapporo, 8 years after the last one.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/yhara">yhara</a><br>
-      <img src="http://usericons.relucks.org/github/yhara" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English and Japanese</p>

--- a/2012/en/schedule/details/75.html
+++ b/2012/en/schedule/details/75.html
@@ -35,7 +35,7 @@ It is the relation there are between the people with the products.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/tricknotes">tricknotes</a><br>
-      <img src="http://usericons.relucks.org/github/tricknotes" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/78.html
+++ b/2012/en/schedule/details/78.html
@@ -28,7 +28,7 @@ A Rails maniac.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/amatsuda">amatsuda</a><br>
-      <img src="http://usericons.relucks.org/github/amatsuda" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/79.html
+++ b/2012/en/schedule/details/79.html
@@ -35,7 +35,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kakutani">kakutani</a><br>
-      <img src="http://usericons.relucks.org/github/kakutani" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/8.html
+++ b/2012/en/schedule/details/8.html
@@ -31,7 +31,7 @@ and active participant in Indian Open Source scene. He has written at in various
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/saurabhbhatia">saurabhbhatia</a><br>
-      <img src="http://usericons.relucks.org/github/saurabhbhatia" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/e0fe062ff7f5d75b8e13773340370db5?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/81.html
+++ b/2012/en/schedule/details/81.html
@@ -27,7 +27,7 @@ I have been developping PukiWiki what&#39;s most popular WikiEngine.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/masuidrive">masuidrive</a><br>
-      <img src="http://usericons.relucks.org/github/masuidrive" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/82.html
+++ b/2012/en/schedule/details/82.html
@@ -22,7 +22,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/apotonick">apotonick</a><br>
-      <img src="http://usericons.relucks.org/github/apotonick" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0fe13386ba69a128e9fadc19ae9d96be?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/84.html
+++ b/2012/en/schedule/details/84.html
@@ -22,7 +22,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/eto">eto</a><br>
-      <img src="http://usericons.relucks.org/github/eto" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/ee67564a1a0e290cccf3c4a415e51c48?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/K02.html
+++ b/2012/en/schedule/details/K02.html
@@ -22,7 +22,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/matz">matz</a><br>
-      <img src="http://usericons.relucks.org/github/matz" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/K03.html
+++ b/2012/en/schedule/details/K03.html
@@ -29,7 +29,7 @@ time he practices astronomy and plays video games.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/drbrain">drbrain</a><br>
-      <img src="http://usericons.relucks.org/github/drbrain" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English</p>

--- a/2012/en/schedule/details/LT01.html
+++ b/2012/en/schedule/details/LT01.html
@@ -24,7 +24,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kentaro">kentaro</a><br>
-      <img src="http://usericons.relucks.org/github/kentaro" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/23f4d5d797a91b6d17d627b90b5a42d9?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT02.html
+++ b/2012/en/schedule/details/LT02.html
@@ -25,7 +25,7 @@ as well as interoperability with other spreadsheet programs like Numbers, LibraO
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/randym">randym</a><br>
-      <img src="http://usericons.relucks.org/github/randym" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/855975ff404621dc525c72b618d95dcc?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>English or 日本語</p>

--- a/2012/en/schedule/details/LT03.html
+++ b/2012/en/schedule/details/LT03.html
@@ -24,7 +24,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takai">takai</a><br>
-      <img src="http://usericons.relucks.org/github/takai" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/cf7b553387b247d737c60cfceabb2cea?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT05.html
+++ b/2012/en/schedule/details/LT05.html
@@ -24,7 +24,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hibariya">hibariya</a><br>
-      <img src="http://usericons.relucks.org/github/hibariya" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT06.html
+++ b/2012/en/schedule/details/LT06.html
@@ -24,7 +24,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kaznum">kaznum</a><br>
-      <img src="http://usericons.relucks.org/github/kaznum" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/fbcf9ed09205a5093069f0a2ccccfdf8?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT09.html
+++ b/2012/en/schedule/details/LT09.html
@@ -31,7 +31,7 @@ So, come on and join in Rails Hackathon in Okinawa!</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/yasulab">yasulab</a><br>
-      <img src="http://usericons.relucks.org/github/yasulab" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/f9e2dfe1e5e7b40cfe5bafa0c730293d?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese/English (時間的にいけそうなら一人同時通訳します.)</p>

--- a/2012/en/schedule/details/LT10.html
+++ b/2012/en/schedule/details/LT10.html
@@ -23,11 +23,7 @@ We have tried to port mruby into TOPPERS/ASP. In TokyuRubyKaigi05, we have talke
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takahashim">takahashim</a><br>
-      <img src="http://usericons.relucks.org/github/takahashim" width="120" height="120">
-    </p>
-    <p>
-      <a href="https://github.com/yurie">yurie</a><br>
-      <img src="http://usericons.relucks.org/github/yurie" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT12.html
+++ b/2012/en/schedule/details/LT12.html
@@ -27,7 +27,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/seki">seki</a><br>
-      <img src="http://usericons.relucks.org/github/seki" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/bdcb9af0b168cf425bac2d3772164bee?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT14.html
+++ b/2012/en/schedule/details/LT14.html
@@ -26,7 +26,7 @@ I explain a way as an example by submit proposal to CFP of TokyoRubyKaigi10.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/bash0C7">bash0C7</a><br>
-      <img src="http://usericons.relucks.org/github/bash0C7" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT15.html
+++ b/2012/en/schedule/details/LT15.html
@@ -24,7 +24,7 @@ I&#39;ll talk how to resolve such problems and best practice of nadoka-san&#39;s
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/znz">znz</a><br>
-      <img src="http://usericons.relucks.org/github/znz" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/LT16.html
+++ b/2012/en/schedule/details/LT16.html
@@ -25,7 +25,7 @@ So, I made Rails templatehandler for ThinReports. </p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takeshinoda">takeshinoda</a><br>
-      <img src="http://usericons.relucks.org/github/takeshinoda" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/P01.html
+++ b/2012/en/schedule/details/P01.html
@@ -26,7 +26,7 @@ locale: en
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kenchan">kenchan</a><br>
-      <img src="http://usericons.relucks.org/github/kenchan" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/676954675cda206b7baae939a82a8ef4?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/en/schedule/details/R02.html
+++ b/2012/en/schedule/details/R02.html
@@ -34,7 +34,7 @@ world&#39;s best technology.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/ihara2525">ihara2525</a><br>
-      <img src="http://usericons.relucks.org/github/ihara2525" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/b16a7b3fa409bb986aef592e21b46ecc?s=140" width="120" height="120">
     </p>
   <h2>Language</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/11.html
+++ b/2012/ja/schedule/details/11.html
@@ -26,7 +26,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/k-tsj">k-tsj</a><br>
-      <img src="http://usericons.relucks.org/github/k-tsj" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/303dd57f37d64288bb4f0336332a8882?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/13.html
+++ b/2012/ja/schedule/details/13.html
@@ -28,7 +28,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hsbt">hsbt</a><br>
-      <img src="http://usericons.relucks.org/github/hsbt" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/14.html
+++ b/2012/ja/schedule/details/14.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/darashi">darashi</a><br>
-      <img src="http://usericons.relucks.org/github/darashi" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Talk will be in Japanese, but slides will be provided in both English and Japanese.</p>

--- a/2012/ja/schedule/details/17.html
+++ b/2012/ja/schedule/details/17.html
@@ -33,7 +33,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/moro">moro</a><br>
-      <img src="http://usericons.relucks.org/github/moro" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/18.html
+++ b/2012/ja/schedule/details/18.html
@@ -30,7 +30,7 @@ Rubyはとても命令的な言語であり、Rubyでは純粋に関数的なプ
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/shugo">shugo</a><br>
-      <img src="http://usericons.relucks.org/github/shugo" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/20.html
+++ b/2012/ja/schedule/details/20.html
@@ -30,7 +30,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/danishkhan">danishkhan</a><br>
-      <img src="http://usericons.relucks.org/github/danishkhan" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/7f81fd5c7792dabca22c433abbfbf0cb?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/22.html
+++ b/2012/ja/schedule/details/22.html
@@ -28,7 +28,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/agrimm">agrimm</a><br>
-      <img src="http://usericons.relucks.org/github/agrimm" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English (slides will be in both English and Japanese)</p>

--- a/2012/ja/schedule/details/25.html
+++ b/2012/ja/schedule/details/25.html
@@ -28,7 +28,7 @@ skills around the beautiful San Francisco.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/calavera">calavera</a><br>
-      <img src="http://usericons.relucks.org/github/calavera" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0c39b828636367fc6e22b7be8c803c74?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/27.html
+++ b/2012/ja/schedule/details/27.html
@@ -44,7 +44,7 @@ GitHub に置いてあるならば、どんなプロジェクトでも統一さ�
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/sorah">sorah</a><br>
-      <img src="http://usericons.relucks.org/github/sorah" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/626ca235e8dab778c5bad6fc10e94ad8?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/28.html
+++ b/2012/ja/schedule/details/28.html
@@ -36,7 +36,7 @@ have such as Rubinius, Radiant CMS or the Heroku Gem.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/daneharrigan">daneharrigan</a><br>
-      <img src="http://usericons.relucks.org/github/daneharrigan" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/e8c88afd8e2c1b5efa3b18e7a6ed6722?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/29.html
+++ b/2012/ja/schedule/details/29.html
@@ -24,7 +24,7 @@ Rubyで書けます！（の予定）</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/authorNari">authorNari</a><br>
-      <img src="http://usericons.relucks.org/github/authorNari" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/3.html
+++ b/2012/ja/schedule/details/3.html
@@ -32,7 +32,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/mrkn">mrkn</a><br>
-      <img src="http://usericons.relucks.org/github/mrkn" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/f92d08fba5207992c4e6b85ab9515a2f?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/37.html
+++ b/2012/ja/schedule/details/37.html
@@ -22,7 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/lanej">lanej</a><br>
-      <img src="http://usericons.relucks.org/github/lanej" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/ba7a9f06b6e43aff99e437309f33c73e?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/40.html
+++ b/2012/ja/schedule/details/40.html
@@ -25,7 +25,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/miyagawa">miyagawa</a><br>
-      <img src="http://usericons.relucks.org/github/miyagawa" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/49e1240c84b221f3dcca57d005a2f569?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English + Japanese</p>

--- a/2012/ja/schedule/details/45.html
+++ b/2012/ja/schedule/details/45.html
@@ -26,7 +26,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/okkez">okkez</a><br>
-      <img src="http://usericons.relucks.org/github/okkez" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/46.html
+++ b/2012/ja/schedule/details/46.html
@@ -26,7 +26,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kyanny">kyanny</a><br>
-      <img src="http://usericons.relucks.org/github/kyanny" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/47.html
+++ b/2012/ja/schedule/details/47.html
@@ -29,7 +29,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kei-s">kei-s</a><br>
-      <img src="http://usericons.relucks.org/github/kei-s" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/48.html
+++ b/2012/ja/schedule/details/48.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/mizzy">mizzy</a><br>
-      <img src="http://usericons.relucks.org/github/mizzy" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0d5d8fb9cc4c06f581825f5a61d3f5f1?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese (A slide is written by English)</p>

--- a/2012/ja/schedule/details/52.html
+++ b/2012/ja/schedule/details/52.html
@@ -30,7 +30,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/yokolet">yokolet</a><br>
-      <img src="http://usericons.relucks.org/github/yokolet" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/e184bc2347f90dd61b509de6eb43a8b6?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/53.html
+++ b/2012/ja/schedule/details/53.html
@@ -35,7 +35,7 @@ asakusa.rbのメール、 ドア係。
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takkanm">takkanm</a><br>
-      <img src="http://usericons.relucks.org/github/takkanm" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/54.html
+++ b/2012/ja/schedule/details/54.html
@@ -28,7 +28,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/tatsuo">tatsuo</a><br>
-      <img src="http://usericons.relucks.org/github/tatsuo" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/56.html
+++ b/2012/ja/schedule/details/56.html
@@ -30,7 +30,7 @@ the release of Ruby 2.0.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/ko1">ko1</a><br>
-      <img src="http://usericons.relucks.org/github/ko1" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/308cbef6e86dfc49cce3b2d4cf42aedc?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/58.html
+++ b/2012/ja/schedule/details/58.html
@@ -22,7 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/johnnymugs">johnnymugs</a><br>
-      <img src="http://usericons.relucks.org/github/johnnymugs" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/642a8d148b8a6969e8e4db525a401636?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/59.html
+++ b/2012/ja/schedule/details/59.html
@@ -28,7 +28,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hotchpotch">hotchpotch</a><br>
-      <img src="http://usericons.relucks.org/github/hotchpotch" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/64.html
+++ b/2012/ja/schedule/details/64.html
@@ -22,7 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/ursm">ursm</a><br>
-      <img src="http://usericons.relucks.org/github/ursm" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/f966e93db0fbaf3aa07f7df5fa136933?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/7.html
+++ b/2012/ja/schedule/details/7.html
@@ -32,7 +32,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kou">kou</a><br>
-      <img src="http://usericons.relucks.org/github/kou" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/ee6ffca720cc428d70247dcd7377dd48?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/70.html
+++ b/2012/ja/schedule/details/70.html
@@ -87,7 +87,7 @@ Michał enjoys pushing people out of their comfort zones and into new rewarding 
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/mehowte">mehowte</a><br>
-      <img src="http://usericons.relucks.org/github/mehowte" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/85977ebfe59c2ee669f2196930f1a701?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English | Japanese</p>

--- a/2012/ja/schedule/details/72.html
+++ b/2012/ja/schedule/details/72.html
@@ -34,7 +34,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/lindaliukas">lindaliukas</a><br>
-      <img src="http://usericons.relucks.org/github/lindaliukas" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/51eb230f66c064daafb36264398c0252?s=140" width="120" height="120">
     </p>
   <h2>講演者</h2>
   <p>Terence Lee</p>
@@ -47,7 +47,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hone">hone</a><br>
-      <img src="http://usericons.relucks.org/github/hone" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/74.html
+++ b/2012/ja/schedule/details/74.html
@@ -30,7 +30,7 @@ Rubyで自給自足している筆者が紹介します。</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/yhara">yhara</a><br>
-      <img src="http://usericons.relucks.org/github/yhara" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English and Japanese</p>

--- a/2012/ja/schedule/details/75.html
+++ b/2012/ja/schedule/details/75.html
@@ -35,7 +35,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/tricknotes">tricknotes</a><br>
-      <img src="http://usericons.relucks.org/github/tricknotes" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/78.html
+++ b/2012/ja/schedule/details/78.html
@@ -30,7 +30,7 @@ A Rails maniac.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/amatsuda">amatsuda</a><br>
-      <img src="http://usericons.relucks.org/github/amatsuda" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/79.html
+++ b/2012/ja/schedule/details/79.html
@@ -36,7 +36,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kakutani">kakutani</a><br>
-      <img src="http://usericons.relucks.org/github/kakutani" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/8.html
+++ b/2012/ja/schedule/details/8.html
@@ -31,7 +31,7 @@ and active participant in Indian Open Source scene. He has written at in various
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/saurabhbhatia">saurabhbhatia</a><br>
-      <img src="http://usericons.relucks.org/github/saurabhbhatia" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/e0fe062ff7f5d75b8e13773340370db5?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/81.html
+++ b/2012/ja/schedule/details/81.html
@@ -27,7 +27,7 @@ I have been developping PukiWiki what&#39;s most popular WikiEngine.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/masuidrive">masuidrive</a><br>
-      <img src="http://usericons.relucks.org/github/masuidrive" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/82.html
+++ b/2012/ja/schedule/details/82.html
@@ -22,7 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/apotonick">apotonick</a><br>
-      <img src="http://usericons.relucks.org/github/apotonick" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0fe13386ba69a128e9fadc19ae9d96be?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/84.html
+++ b/2012/ja/schedule/details/84.html
@@ -22,7 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/eto">eto</a><br>
-      <img src="http://usericons.relucks.org/github/eto" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/ee67564a1a0e290cccf3c4a415e51c48?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/K02.html
+++ b/2012/ja/schedule/details/K02.html
@@ -22,7 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/matz">matz</a><br>
-      <img src="http://usericons.relucks.org/github/matz" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/K03.html
+++ b/2012/ja/schedule/details/K03.html
@@ -29,7 +29,7 @@ time he practices astronomy and plays video games.</p>
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/drbrain">drbrain</a><br>
-      <img src="http://usericons.relucks.org/github/drbrain" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English</p>

--- a/2012/ja/schedule/details/LT01.html
+++ b/2012/ja/schedule/details/LT01.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kentaro">kentaro</a><br>
-      <img src="http://usericons.relucks.org/github/kentaro" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/23f4d5d797a91b6d17d627b90b5a42d9?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT02.html
+++ b/2012/ja/schedule/details/LT02.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/randym">randym</a><br>
-      <img src="http://usericons.relucks.org/github/randym" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/855975ff404621dc525c72b618d95dcc?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>English or 日本語</p>

--- a/2012/ja/schedule/details/LT03.html
+++ b/2012/ja/schedule/details/LT03.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takai">takai</a><br>
-      <img src="http://usericons.relucks.org/github/takai" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/cf7b553387b247d737c60cfceabb2cea?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT05.html
+++ b/2012/ja/schedule/details/LT05.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/hibariya">hibariya</a><br>
-      <img src="http://usericons.relucks.org/github/hibariya" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT06.html
+++ b/2012/ja/schedule/details/LT06.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kaznum">kaznum</a><br>
-      <img src="http://usericons.relucks.org/github/kaznum" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/fbcf9ed09205a5093069f0a2ccccfdf8?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT09.html
+++ b/2012/ja/schedule/details/LT09.html
@@ -29,7 +29,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/yasulab">yasulab</a><br>
-      <img src="http://usericons.relucks.org/github/yasulab" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/f9e2dfe1e5e7b40cfe5bafa0c730293d?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese/English (時間的にいけそうなら一人同時通訳します.)</p>

--- a/2012/ja/schedule/details/LT10.html
+++ b/2012/ja/schedule/details/LT10.html
@@ -22,11 +22,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takahashim">takahashim</a><br>
-      <img src="http://usericons.relucks.org/github/takahashim" width="120" height="120">
-    </p>
-    <p>
-      <a href="https://github.com/yurie">yurie</a><br>
-      <img src="http://usericons.relucks.org/github/yurie" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT12.html
+++ b/2012/ja/schedule/details/LT12.html
@@ -27,7 +27,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/seki">seki</a><br>
-      <img src="http://usericons.relucks.org/github/seki" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/bdcb9af0b168cf425bac2d3772164bee?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT14.html
+++ b/2012/ja/schedule/details/LT14.html
@@ -26,7 +26,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/bash0C7">bash0C7</a><br>
-      <img src="http://usericons.relucks.org/github/bash0C7" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT15.html
+++ b/2012/ja/schedule/details/LT15.html
@@ -27,7 +27,7 @@ nadoka さんでの m17n 対応の最善の方法は何なのか、
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/znz">znz</a><br>
-      <img src="http://usericons.relucks.org/github/znz" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/LT16.html
+++ b/2012/ja/schedule/details/LT16.html
@@ -26,7 +26,7 @@ ThinReporsは素晴らしいPDFのジェネレータであり、GUIデザイナ�
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/takeshinoda">takeshinoda</a><br>
-      <img src="http://usericons.relucks.org/github/takeshinoda" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/P01.html
+++ b/2012/ja/schedule/details/P01.html
@@ -31,7 +31,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/kenchan">kenchan</a><br>
-      <img src="http://usericons.relucks.org/github/kenchan" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/676954675cda206b7baae939a82a8ef4?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>

--- a/2012/ja/schedule/details/R02.html
+++ b/2012/ja/schedule/details/R02.html
@@ -24,7 +24,7 @@ locale: ja
   <h3>GitHub</h3>
         <p>
       <a href="https://github.com/ihara2525">ihara2525</a><br>
-      <img src="http://usericons.relucks.org/github/ihara2525" width="120" height="120">
+      <img src="https://secure.gravatar.com/avatar/b16a7b3fa409bb986aef592e21b46ecc?s=140" width="120" height="120">
     </p>
   <h2>発表言語</h3>
   <p>Japanese</p>


### PR DESCRIPTION
今までは [usericons](http://usericons.relucks.org) というサービスを利用してアイコン画像を表示していましたが、最近このサービスの調子が悪いので gravatar から直接画像を取得するようにしました。

また、yaml で管理している github アカウントから gravatar id を取得するために、以下のコードを使いました。

``` ruby
#!/usr/bin/env ruby
require 'yaml'
require 'octokit'

Dir['presentations/*.yml'].each do |path|
  rows = File.readlines(path)
  github_row = rows.detect {|row| row =~ /^ +github: / }
  next unless github_row
  gravatar_row = github_row.sub('github: ', 'gravatar: ')

  data = YAML.load_file(path)
  data['presenters'].each do |presenter|
    [*presenter['github']].each do |github_account|
      user_data = Octokit.user(github_account)
      gravatar_id = user_data.gravatar_id
      gravatar_row = gravatar_row.sub(github_account, gravatar_id)
    end
  end
  rows.insert(rows.index(github_row) + 1, gravatar_row)
  File.write(path, rows.join)
end
```
